### PR TITLE
feat: add e2e integration validation for x402 weather flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,22 @@ git worktree remove --force ../project-task-a
   pnpm mcpserver run delete
   ```
 
+## E2E 結合テスト
+
+以下のコマンドで、`mcpserver -> x402FetchClient -> x402server` の結合動作を in-process で検証できます。
+
+```bash
+pnpm run test:e2e
+```
+
+このE2Eでは次を確認します。
+
+- x402server / mcpserver のヘルスチェック応答
+- `get_weather` ツールから `/weather` への到達と正常応答
+- 不正都市名（404）のエラー伝搬
+- 都市パラメータ欠落時（バリデーション）のエラー応答
+- 未決済時の402エラー伝搬
+
 ## cc-sdd + VibeKanban + GitWorkTreeによる開発のワークフロー
 
 - 0. プロダクトのビジョン、コンセプトを策定する

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "format": "biome format --write .",
     "build": "pnpm -r run build",
     "test": "pnpm -r run test",
+    "test:e2e": "pnpm --filter mcpserver test -- e2e-validation.test.ts",
     "ci": "pnpm run build && pnpm run test",
     "x402server": "pnpm --filter x402server",
     "mcpserver": "pnpm --filter mcpserver"

--- a/pkgs/mcpserver/__tests__/e2e-validation.test.ts
+++ b/pkgs/mcpserver/__tests__/e2e-validation.test.ts
@@ -1,0 +1,193 @@
+import { x402Version } from "@x402/core";
+import { ExactEvmScheme } from "@x402/evm";
+import { privateKeyToAccount } from "viem/accounts";
+import { describe, expect, it } from "vitest";
+import { createApp as createMcpApp } from "../src/index";
+import { createX402FetchClient, type X402FetchClientEnv } from "../src/x402-fetch-client";
+import { createApp as createX402App } from "../../x402server/src/app";
+
+const parseSseMessageData = (ssePayload: string): unknown => {
+  const dataLine = ssePayload.split("\n").find((line) => line.startsWith("data: "));
+  if (!dataLine) {
+    throw new Error("SSE payload does not contain a data line");
+  }
+
+  return JSON.parse(dataLine.slice("data: ".length));
+};
+
+const initializeMcpServer = async (app: ReturnType<typeof createMcpApp>, env: X402FetchClientEnv) => {
+  const initResponse = await app.request(
+    "/mcp",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "initialize-1",
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: {
+            name: "vitest-e2e-client",
+            version: "1.0.0",
+          },
+        },
+      }),
+    },
+    env,
+  );
+
+  expect(initResponse.status).toBe(200);
+};
+
+const createAppConnectedWithX402Server = (x402App: ReturnType<typeof createX402App>) => {
+  return createMcpApp({
+    getWeatherToolDepsFactory: (getEnv) => ({
+      createClient: (env) =>
+        createX402FetchClient(env, {
+          fetchImpl: (input, init) => {
+            const url = new URL(typeof input === "string" ? input : input.toString());
+            const pathWithQuery = `${url.pathname}${url.search}`;
+
+            return x402App.request(pathWithQuery, {
+              method: init?.method ?? "GET",
+              headers: init?.headers,
+              body: init?.body as BodyInit | null | undefined,
+            });
+          },
+          wrapFetchWithPaymentFromConfig: (fetchImpl) => fetchImpl,
+          privateKeyToAccount,
+          createSchemeClient: (account) => new ExactEvmScheme(account),
+        }),
+      getEnv,
+    }),
+  });
+};
+
+const callGetWeatherTool = async (
+  app: ReturnType<typeof createMcpApp>,
+  city: string,
+  env: X402FetchClientEnv,
+) => {
+  const response = await app.request(
+    "/mcp",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: `tool-call-${city}`,
+        method: "tools/call",
+        params: {
+          name: "get_weather",
+          arguments: { city },
+        },
+      }),
+    },
+    env,
+  );
+
+  expect(response.status).toBe(200);
+  return parseSseMessageData(await response.text()) as {
+    result?: {
+      isError?: boolean;
+      content?: Array<{ type: string; text: string }>;
+    };
+    error?: { message?: string };
+  };
+};
+
+const unpaidFacilitatorClient = {
+  async getSupported() {
+    return {
+      kinds: [{ x402Version, scheme: "exact", network: "eip155:84532" }],
+      extensions: [],
+      signers: {},
+    };
+  },
+  async verify() {
+    return { isValid: false, invalidReason: "missing payment" };
+  },
+  async settle() {
+    return { success: true, transaction: "0x", network: "eip155:84532" };
+  },
+};
+
+describe("e2e validation: mcpserver <-> x402server", () => {
+  const env: X402FetchClientEnv = {
+    CLIENT_PRIVATE_KEY: "0x1111111111111111111111111111111111111111111111111111111111111111",
+    X402_SERVER_URL: "http://x402.local",
+  };
+
+  it("responds healthy from both services", async () => {
+    const x402App = createX402App(undefined, { enablePayment: false });
+    const mcpApp = createAppConnectedWithX402Server(x402App);
+
+    const x402Health = await x402App.request("/");
+    const mcpHealth = await mcpApp.request("/");
+
+    expect(x402Health.status).toBe(200);
+    await expect(x402Health.json()).resolves.toEqual({ status: "ok" });
+    expect(mcpHealth.status).toBe(200);
+    await expect(mcpHealth.json()).resolves.toEqual({ status: "ok", service: "mcpserver" });
+  });
+
+  it("returns weather data through MCP get_weather tool", async () => {
+    const x402App = createX402App(undefined, { enablePayment: false });
+    const mcpApp = createAppConnectedWithX402Server(x402App);
+    await initializeMcpServer(mcpApp, env);
+
+    const body = await callGetWeatherTool(mcpApp, "Tokyo", env);
+    const text = body.result?.content?.[0]?.text ?? "";
+
+    expect(body.error).toBeUndefined();
+    expect(body.result?.isError).toBeUndefined();
+    expect(text).toContain("City: Tokyo");
+    expect(text).toContain("Condition:");
+  });
+
+  it("propagates city not found errors to MCP response", async () => {
+    const x402App = createX402App(undefined, { enablePayment: false });
+    const mcpApp = createAppConnectedWithX402Server(x402App);
+    await initializeMcpServer(mcpApp, env);
+
+    const body = await callGetWeatherTool(mcpApp, "Atlantis", env);
+    const text = body.result?.content?.[0]?.text ?? "";
+
+    expect(body.error).toBeUndefined();
+    expect(body.result?.isError).toBe(true);
+    expect(text).toContain("weather request failed (404): city not found");
+  });
+
+  it("propagates validation errors when city is missing", async () => {
+    const x402App = createX402App(undefined, { enablePayment: false });
+    const mcpApp = createAppConnectedWithX402Server(x402App);
+    await initializeMcpServer(mcpApp, env);
+
+    const body = await callGetWeatherTool(mcpApp, "", env);
+    const errorText = body.error?.message ?? body.result?.content?.[0]?.text ?? "";
+    expect(errorText).toContain("city is required");
+  });
+
+  it("propagates x402 payment-required errors from protected weather endpoint", async () => {
+    const x402App = createX402App(undefined, {
+      payment: { facilitatorClient: unpaidFacilitatorClient as never },
+    });
+    const mcpApp = createAppConnectedWithX402Server(x402App);
+    await initializeMcpServer(mcpApp, env);
+
+    const body = await callGetWeatherTool(mcpApp, "Tokyo", env);
+    const text = body.result?.content?.[0]?.text ?? "";
+
+    expect(body.error).toBeUndefined();
+    expect(body.result?.isError).toBe(true);
+    expect(text).toContain("x402 payment failed (402):");
+  });
+});

--- a/pkgs/mcpserver/__tests__/x402-fetch-client.test.ts
+++ b/pkgs/mcpserver/__tests__/x402-fetch-client.test.ts
@@ -69,6 +69,19 @@ describe("createX402FetchClient", () => {
     await expect(client.fetchWeather("Tokyo")).rejects.toThrow("x402 payment failed (402): payment rejected");
   });
 
+  it("uses details field when message is not present in error response", async () => {
+    const { paymentFetch, deps } = createDeps();
+    paymentFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "settlement failed", details: "missing payment" }), {
+        status: 402,
+      }),
+    );
+
+    const client = createX402FetchClient(dummyEnv, deps);
+
+    await expect(client.fetchWeather("Tokyo")).rejects.toThrow("x402 payment failed (402): missing payment");
+  });
+
   it("throws an HTTP error with status when response is not ok", async () => {
     const { paymentFetch, deps } = createDeps();
     paymentFetch.mockResolvedValueOnce(

--- a/pkgs/mcpserver/src/index.ts
+++ b/pkgs/mcpserver/src/index.ts
@@ -3,70 +3,78 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { createDefaultGetWeatherToolDeps, registerGetWeatherTool } from "./weather-tool";
+import type { GetWeatherToolDeps } from "./weather-tool";
 import type { X402FetchClientEnv } from "./x402-fetch-client";
 
-const app = new Hono();
-
-const mcpServer = new McpServer({
-  name: "x402-weather-payment-mcpserver",
-  version: "1.0.0",
-});
-
-let transport: StreamableHTTPTransport | null = null;
-let currentEnv: X402FetchClientEnv | null = null;
-
-registerGetWeatherTool(
-  mcpServer,
-  createDefaultGetWeatherToolDeps(
-    () =>
-      currentEnv ?? {
-        CLIENT_PRIVATE_KEY: "",
-        X402_SERVER_URL: "",
-      },
-  ),
-);
-
-const connectServerIfNeeded = async (): Promise<StreamableHTTPTransport> => {
-  if (mcpServer.isConnected() && transport) {
-    return transport;
-  }
-
-  transport = new StreamableHTTPTransport();
-  await mcpServer.connect(transport);
-  return transport;
+type CreateAppOptions = {
+  getWeatherToolDepsFactory?: (getEnv: () => X402FetchClientEnv) => GetWeatherToolDeps;
 };
 
-const closeServerConnection = async (): Promise<void> => {
-  if (transport) {
-    await transport.close();
-    transport = null;
-  }
-
-  if (mcpServer.isConnected()) {
-    await mcpServer.close();
-  }
-};
-
-app.use("/mcp", cors());
-
-app.get("/", (c) => {
-  return c.json({
-    status: "ok",
-    service: "mcpserver",
+export const createApp = (options: CreateAppOptions = {}): Hono => {
+  const app = new Hono();
+  const mcpServer = new McpServer({
+    name: "x402-weather-payment-mcpserver",
+    version: "1.0.0",
   });
-});
 
-app.all("/mcp", async (c) => {
-  currentEnv = c.env as X402FetchClientEnv;
-  const currentTransport = await connectServerIfNeeded();
+  let transport: StreamableHTTPTransport | null = null;
+  let currentEnv: X402FetchClientEnv | null = null;
 
-  try {
-    return await currentTransport.handleRequest(c);
-  } finally {
-    if (c.req.method === "DELETE") {
-      await closeServerConnection();
+  const getEnv = () =>
+    currentEnv ?? {
+      CLIENT_PRIVATE_KEY: "",
+      X402_SERVER_URL: "",
+    };
+  const getWeatherToolDepsFactory = options.getWeatherToolDepsFactory ?? createDefaultGetWeatherToolDeps;
+
+  registerGetWeatherTool(mcpServer, getWeatherToolDepsFactory(getEnv));
+
+  const connectServerIfNeeded = async (): Promise<StreamableHTTPTransport> => {
+    if (mcpServer.isConnected() && transport) {
+      return transport;
     }
-  }
-});
+
+    transport = new StreamableHTTPTransport();
+    await mcpServer.connect(transport);
+    return transport;
+  };
+
+  const closeServerConnection = async (): Promise<void> => {
+    if (transport) {
+      await transport.close();
+      transport = null;
+    }
+
+    if (mcpServer.isConnected()) {
+      await mcpServer.close();
+    }
+  };
+
+  app.use("/mcp", cors());
+
+  app.get("/", (c) => {
+    return c.json({
+      status: "ok",
+      service: "mcpserver",
+    });
+  });
+
+  app.all("/mcp", async (c) => {
+    currentEnv = c.env as X402FetchClientEnv;
+    const currentTransport = await connectServerIfNeeded();
+
+    try {
+      return await currentTransport.handleRequest(c);
+    } finally {
+      if (c.req.method === "DELETE") {
+        await closeServerConnection();
+      }
+    }
+  });
+
+  return app;
+};
+
+const app = createApp();
 
 export default app;

--- a/pkgs/mcpserver/src/weather-tool.ts
+++ b/pkgs/mcpserver/src/weather-tool.ts
@@ -13,6 +13,7 @@ type GetWeatherToolDeps = {
   createClient: (env: X402FetchClientEnv) => WeatherFetchClient;
   getEnv: () => X402FetchClientEnv;
 };
+export type { GetWeatherToolDeps };
 
 type GetWeatherToolInput = z.infer<typeof getWeatherInputSchema>;
 

--- a/pkgs/mcpserver/src/x402-fetch-client.ts
+++ b/pkgs/mcpserver/src/x402-fetch-client.ts
@@ -11,6 +11,8 @@ export type WeatherData = {
 
 type ErrorResponse = {
   message?: string;
+  error?: string;
+  details?: string;
 };
 
 type X402FetchClientEnv = {
@@ -39,6 +41,12 @@ const parseErrorMessage = async (response: Response): Promise<string> => {
     const parsed = (await response.json()) as ErrorResponse;
     if (parsed?.message) {
       return parsed.message;
+    }
+    if (parsed?.details) {
+      return parsed.details;
+    }
+    if (parsed?.error) {
+      return parsed.error;
     }
   } catch {
     // ignore json parse failure

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.4
         version: 2.4.4
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
 
   pkgs/mcpserver:
     dependencies:
@@ -2832,7 +2829,8 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript@5.9.3: {}
+  typescript@5.9.3:
+    optional: true
 
   undici-types@6.19.8: {}
 


### PR DESCRIPTION
## Summary
- add in-process end-to-end validation tests for mcpserver -> x402FetchClient -> x402server
- add MCP app factory (createApp) to allow dependency injection for integration tests while preserving default export behavior
- improve x402 client error parsing to surface details/error fields from upstream responses
- add a dedicated root script test:e2e and document E2E validation scope in README

## Validation
- pnpm --filter mcpserver test
- pnpm --filter x402server test
- pnpm run test:e2e
- pnpm run test

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * エンドツーエンド（E2E）テストを追加し、天気取得・エラー伝播・支払い検証など複数シナリオを検証可能に
  * アプリ初期化がカスタマイズ可能になり、依存差し替えで挙動を制御可能に

* **Tests**
  * E2Eテスト用スクリプトを追加（ローカル実行コマンドを提供）
  * エラーメッセージ処理に関する追加検証を実装し、詳細情報を優先表示する挙動を確認

* **Documentation**
  * E2E実行手順と開発ワークフロー手順を追記
<!-- end of auto-generated comment: release notes by coderabbit.ai -->